### PR TITLE
Simplify the process of preparing metadata components

### DIFF
--- a/openlcs/libs/sc_handler.py
+++ b/openlcs/libs/sc_handler.py
@@ -102,21 +102,6 @@ class SourceContainerHandler(object):
         return srpm_filepath if os.path.isfile(srpm_filepath) else None
 
     @staticmethod
-    def get_source_of_misc_component(misc_dir, nvr):
-        """
-        Compress the metadata files to tar file
-        """
-        # Named the source tar file that unified with misc component
-        tar_file = nvr + '-metadata.tar.gz'
-        # Compress the metadata files to misc nvr tar file
-        try:
-            tar_filepath = os.path.join(os.path.dirname(misc_dir), tar_file)
-            compress_source_to_tarball(tar_filepath, misc_dir)
-        except RuntimeError as err:
-            raise RuntimeError(err) from None
-        return tar_filepath
-
-    @staticmethod
     def get_source_of_remote_source_components(rs_dir, component):
         """
         Get the source tarball for remote source components.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,3 +26,4 @@ ijson==3.1.4
 httpx==0.23.0
 uvloop==0.16.0
 django-mptt==0.13.4
+checksumdir==1.2.0


### PR DESCRIPTION
This is done by passing by the metadata source directory, without compressing the given directory. Checksum varies each time a new archive is generated thus failed the duplicate check.

Fixes OLCS-267