### PR TITLE
Create celery meta tables explicitly for test database.

### DIFF
--- a/tests/functional/celery_meta.sql
+++ b/tests/functional/celery_meta.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS celery_taskmeta (
+    id integer NOT NULL,
+    task_id character varying(155),
+    status character varying(50),
+    result bytea,
+    date_done timestamp without time zone,
+    traceback text,
+    name character varying(155),
+    args bytea,
+    kwargs bytea,
+    worker character varying(155),
+    retries integer,
+    queue character varying(155)
+);
+ALTER TABLE celery_taskmeta
+    ADD CONSTRAINT celery_taskmeta_pkey PRIMARY KEY (id);
+ALTER TABLE celery_taskmeta
+    ADD CONSTRAINT celery_taskmeta_task_id_key UNIQUE (task_id);
+
+CREATE TABLE IF NOT EXISTS celery_tasksetmeta (
+    id integer NOT NULL,
+    taskset_id character varying(155),
+    result bytea,
+    date_done timestamp without time zone
+);
+ALTER TABLE celery_tasksetmeta
+    ADD CONSTRAINT celery_tasksetmeta_pkey PRIMARY KEY (id);
+ALTER TABLE celery_tasksetmeta
+    ADD CONSTRAINT celery_tasksetmeta_taskset_id_key UNIQUE (taskset_id);

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -53,6 +53,9 @@ def openlcs_setup(redis_nooproc):
 def django_db_setup(django_db_setup, django_db_blocker):
     # Note: Look at README.md how to properly create the database dump
     with django_db_blocker.unblock():
+        # make sure celery meta tables exist before loaddata
+        with connection.cursor() as cursor:
+            cursor.execute(open(join(TESTDIR, "celery_meta.sql"), "r").read())
         call_command(
             'loaddata',
             join(dirname(__file__), 'database_data.json'))


### PR DESCRIPTION
The celery meta tables are not created automatically after migration, which would cause issues under certain circumstances.