### PR TITLE
deploy-to-dev jenkins to update dev instance in MP+

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -167,7 +167,7 @@ deploy-to-dev:
    - >
       tower-cli job launch -J "OpenLCS deploy dev" --monitor --no-input --insecure
       -e "openlcs_image_tag: dev"
-      -h "$TOWER_HOST" -t "$TOWER_TOKEN"
+      -h "$AAP_HOST" -t "$AAP_CI_CD_TOKEN"
 
 # ======== build-release-image ========
 build-release-image:


### PR DESCRIPTION
The "AAP_HOST", "AAP_CI_CD_TOKEN" are stored in the variables in gitlab, and that the token was generated from user "openlcs-ci-cd" in aap.

OLCS-300