### PR TITLE
Fix tox failed with pass_env values

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ sitepackages =  true
 [testenv]
 basepython = python3.8
 setenv = PYTHONHASHSEED=0
-passenv = KOJI* CORGI* LDAP* OLCS*
+passenv = KOJI*, CORGI*, LDAP*, OLCS*
 install_command = python -m pip install {opts} {packages}
 deps = -r{toxinidir}/requirements/devel.txt
 


### PR DESCRIPTION
pass_env in tox v4 uses comma or the newline as value separator.