### PR TITLE
get rid of redundant methods

### DIFF
--- a/openlcs/products/models.py
+++ b/openlcs/products/models.py
@@ -4,7 +4,6 @@ from django.contrib.contenttypes.fields import (
     GenericForeignKey,
     GenericRelation,
 )
-import koji
 from datetime import datetime
 from mptt.models import MPTTModel, TreeForeignKey
 from django.core.cache import cache
@@ -71,42 +70,6 @@ class Release(models.Model):
             # release node will not have a parent.
             parent=None,
         )
-
-    def create_component(self, data):
-        from packages.models import Component
-        component, _ = Component.objects.update_or_create(
-            name=data.get('name'),
-            version=data.get('version'),
-            release=data.get('release'),
-            arch=data.get('arch'),
-            type=data.get('type'),
-            defaults={
-                'summary_license': data.get('summary_license'),
-            })
-        return component
-
-    def add_components_from_nvrs(self, nvrs, type="RPM", arch="src"):
-        release_node, _ = self.get_or_create_release_node()
-        # Not add container nvr as "RPM" component.
-        nvrs = [nvr for nvr in nvrs if 'container-source' not in nvr]
-        for nvr in nvrs:
-            nvr_dict = koji.parse_NVR(nvr)
-            # we don't have purl, summary_license based on nvrs.
-            component_data = {
-                'name': nvr_dict.get('name'),
-                'version': nvr_dict.get('version'),
-                'release': nvr_dict.get('release'),
-                # Unless explicitly specified, we will use default value for
-                # `type` and `arch` for components generated from nvrs.
-                'type': type,
-                'arch': arch,
-                'summary_license': '',
-            }
-            component = self.create_component(component_data)
-            # attach component to the release_node tree.
-            component.release_nodes.get_or_create(
-                parent=release_node
-            )
 
 
 def sync_release_updated_at(*args, sender=None, instance=None, **kwargs):


### PR DESCRIPTION
Not used anywhere. Increased maintenance burden.