### PR TITLE
Fixes KeyError for 'sources' when accessing comsumed source components

### DIFF
--- a/openlcs/libs/corgi.py
+++ b/openlcs/libs/corgi.py
@@ -597,7 +597,11 @@ class CorgiConnector:
                 try:
                     component = next(components)
                 except StopIteration:
-                    yield result
+                    # StopIteration may appear when `should_yield_data` is
+                    # False, i.e., the last iteration(before exhausting) may
+                    # accumulates components less than `num_components`.
+                    if len(result) > 1:
+                        yield result
                     break
                 else:
                     subscription_sources, subscription_missings = [], []

--- a/openlcsd/flow/tasks.py
+++ b/openlcsd/flow/tasks.py
@@ -1495,7 +1495,7 @@ def populate_source_components(context, engine):
         source_components = next(generator)
     except StopIteration:
         # Stop the flow since all chunks are consumed.
-        engine.break_current_loop()
+        engine.stop()
     else:
         context["source_components"] = source_components
 


### PR DESCRIPTION
Also use `stop` instead of `break_current_loop` to control the flow.

Fixes OLCS-510