### PR TITLE
Fixes OLCS-515

### DIFF
--- a/openlcs/libs/corgi.py
+++ b/openlcs/libs/corgi.py
@@ -163,7 +163,7 @@ class CorgiConnector:
         """
         Determines which fields to sync for a specified component.
         """
-        sync_fields = CORGI_SYNC_FIELDS
+        sync_fields = CORGI_SYNC_FIELDS.copy()
         # Don't overwrite `license_declared` if corgi already has.
         if component.get("license_declared"):
             sync_fields.remove("license_declared")


### PR DESCRIPTION
Need to either move the variable inside the class function, or to explicitly copy it to avoid mutation.

Fixes 515