### PR TITLE
Get rid of SourceImportMixin

### DIFF
--- a/openlcs/packages/mixins.py
+++ b/openlcs/packages/mixins.py
@@ -28,17 +28,6 @@ class SourceImportMixin:
     Package import transaction mixin
     """
     @staticmethod
-    def create_paths(source, paths):
-        """
-        Create source file paths.
-        """
-        if paths:
-            path_objs = [Path(source=source,
-                              file=File.objects.get(swhid=p.get('file')),
-                              path=p.get('path')) for p in paths]
-            Path.objects.bulk_create(path_objs)
-
-    @staticmethod
     def create_product(product_name, description=""):
 
         p, _ = Product.objects.update_or_create(

--- a/openlcs/packages/mixins.py
+++ b/openlcs/packages/mixins.py
@@ -27,19 +27,6 @@ class SourceImportMixin:
     """
     Package import transaction mixin
     """
-
-    @staticmethod
-    def create_files(file_objs):
-        """
-        Create source files.
-        """
-        if file_objs:
-            files = File.objects.bulk_create(file_objs)
-            serializer = BulkFileSerializer({'files': files})
-            return serializer.data
-        else:
-            return {'message': 'No files created.'}
-
     @staticmethod
     def create_paths(source, paths):
         """

--- a/openlcs/packages/mixins.py
+++ b/openlcs/packages/mixins.py
@@ -5,15 +5,9 @@ from django.db import transaction
 from django.db.models import Q
 from django.db.utils import IntegrityError
 
-from libs.corgi import CorgiConnector
 from packages.models import (
     File,
-    Path,
     Source
-)
-from packages.serializers import BulkFileSerializer
-from products.models import (
-    Product
 )
 from reports.models import (
     CopyrightDetection,
@@ -21,44 +15,6 @@ from reports.models import (
     FileLicenseScan,
     LicenseDetection
 )
-
-
-class SourceImportMixin:
-    """
-    Package import transaction mixin
-    """
-    @staticmethod
-    def create_product(product_name, description=""):
-
-        p, _ = Product.objects.update_or_create(
-            name=product_name,
-            display_name=product_name,
-            defaults={
-                "description": description,
-            },
-        )
-        return p
-
-    def create_product_release(self, name):
-        """
-        Create product and release.
-        """
-        connector = CorgiConnector()
-        product_data = connector.get_product_version(name)
-        if product_data:
-            product_name = product_data.get('products')[0].get('name')
-            product_name_release = product_data.get("name")
-            product_release = product_name_release[len(product_name)+1:]
-            description = product_data.get("description", "")
-
-            # Create product instance
-            product = self.create_product(product_name, description)
-            # Create release
-            product.add_release(
-                name=product_name_release,
-                version=product_release,
-                notes=description,
-            )
 
 
 class SaveScanResultMixin:

--- a/openlcs/packages/models.py
+++ b/openlcs/packages/models.py
@@ -123,6 +123,19 @@ class Path(models.Model):
             ),
         ]
 
+    @classmethod
+    def bulk_create_objects(cls, source, paths, batch_size=1000):
+        file_ids = [p.get('file') for p in paths]
+        files = File.objects.filter(swhid__in=file_ids).values('swhid', 'id')
+        file_mapping = {file['swhid']: file['id'] for file in files}
+        path_objs = [
+            Path(source=source,
+                 file_id=file_mapping[p.get('file')],
+                 path=p.get('path')) for p in paths
+        ]
+
+        Path.objects.bulk_create(path_objs, batch_size=batch_size)
+
     def __str__(self):
         return f'{self.source}, {self.path}'
 

--- a/openlcs/packages/views.py
+++ b/openlcs/packages/views.py
@@ -572,7 +572,7 @@ class PackageImportTransactionView(APIView, SourceImportMixin):
                                 file_objs,
                                 batch_size=1000)
                         if paths:
-                            self.create_paths(source_obj, paths)
+                            Path.bulk_create_objects(source_obj, paths)
                         if component:
                             component_obj = Component.\
                                 update_or_create_component(component)

--- a/openlcs/packages/views.py
+++ b/openlcs/packages/views.py
@@ -566,7 +566,11 @@ class PackageImportTransactionView(APIView, SourceImportMixin):
                     with transaction.atomic():
                         source_obj = Source.objects.create(**source)
                         if file_objs:
-                            self.create_files(file_objs)
+                            # limit the number of objects created in one
+                            #  query, which reduces memory consumption
+                            File.objects.bulk_create(
+                                file_objs,
+                                batch_size=1000)
                         if paths:
                             self.create_paths(source_obj, paths)
                         if component:

--- a/openlcs/packages/views.py
+++ b/openlcs/packages/views.py
@@ -10,10 +10,7 @@ from django_celery_beat.models import (
     CrontabSchedule
 )
 from libs.parsers import parse_manifest_file
-from packages.mixins import (
-    SourceImportMixin,
-    SaveScanResultMixin,
-)
+from packages.mixins import SaveScanResultMixin
 from packages.models import (
     Component,
     ComponentSubscription,
@@ -52,7 +49,7 @@ from rest_framework.viewsets import ModelViewSet
 
 
 # Create your views here.
-class FileViewSet(ModelViewSet, SourceImportMixin):
+class FileViewSet(ModelViewSet):
     """
     API endpoint that allows files to be viewed or edited.
     """
@@ -361,7 +358,7 @@ file first, it should contain the following parameters:
         return Response(data=resp)
 
 
-class PathViewSet(ModelViewSet, SourceImportMixin):
+class PathViewSet(ModelViewSet):
     """
     API endpoint that allows Paths to be viewed or edited.
     """
@@ -473,7 +470,7 @@ Token your_token'
         return super().retrieve(request, *args, **kwargs)
 
 
-class PackageImportTransactionView(APIView, SourceImportMixin):
+class PackageImportTransactionView(APIView):
     """
     Package import transaction
 


### PR DESCRIPTION
Fixes OLCS-608

- Drop SourceImportMixin.create_files
- Remove create_paths from mixin and gave improvements on bulk creation.
